### PR TITLE
fix mck_io_num

### DIFF
--- a/src/AudioKitHAL.h
+++ b/src/AudioKitHAL.h
@@ -297,6 +297,9 @@ class AudioKit {
       KIT_LOGI("- ws_io_num: %d", pin_config.ws_io_num);
       KIT_LOGI("- data_out_num: %d", pin_config.data_out_num);
       KIT_LOGI("- data_in_num: %d", pin_config.data_in_num);
+#if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(4, 4, 0)
+      KIT_LOGI("- mck_io_num: %d", pin_config.mck_io_num);
+#endif
 
       if (i2s_set_pin(cfg.i2s_num, &pin_config) != ESP_OK) {
         KIT_LOGE("i2s_set_pin");

--- a/src/AudioKitHAL.h
+++ b/src/AudioKitHAL.h
@@ -297,7 +297,6 @@ class AudioKit {
       KIT_LOGI("- ws_io_num: %d", pin_config.ws_io_num);
       KIT_LOGI("- data_out_num: %d", pin_config.data_out_num);
       KIT_LOGI("- data_in_num: %d", pin_config.data_in_num);
-      KIT_LOGI("- mck_io_num: %d", pin_config.mck_io_num);
 
       if (i2s_set_pin(cfg.i2s_num, &pin_config) != ESP_OK) {
         KIT_LOGE("i2s_set_pin");


### PR DESCRIPTION
`mck_io_num` does not exist in `i2s_pin_config_t`